### PR TITLE
Back-merge main hardening into develop

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,34 +1,62 @@
-
 name: Terraform CI/CD
 
 on:
   push:
     branches:
       - main
+      - qa
+      - develop
   pull_request:
     branches:
       - main
+      - qa
+      - develop
 
 jobs:
   terraform:
-    name: 'Terraform Format, Validate, Plan'
+    name: Terraform Format, Validate, Plan
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed Terraform files
+        id: tf_changes
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE_SHA="${{ github.event.before }}"
+            HEAD_SHA="${{ github.sha }}"
+          fi
+
+          echo "Checking Terraform changes between $BASE_SHA and $HEAD_SHA"
+          CHANGED_TF_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- '*.tf' || true)
+
+          if [ -n "$CHANGED_TF_FILES" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Changed Terraform files:"
+            echo "$CHANGED_TF_FILES"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No Terraform files changed. Skipping Terraform validation for this documentation-only change."
+          fi
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
+        if: steps.tf_changes.outputs.changed == 'true'
+        uses: hashicorp/setup-terraform@v3
 
       - name: Terraform Format
+        if: steps.tf_changes.outputs.changed == 'true'
         run: terraform fmt -check -recursive
 
-      - name: Terraform Init
-        run: terraform init
-
-      - name: Terraform Validate
-        run: terraform validate
-
-      - name: Terraform Plan
-        run: terraform plan -out=tfplan
+      - name: Terraform Validate Notice
+        if: steps.tf_changes.outputs.changed == 'true'
+        run: |
+          echo "Terraform files changed. Run module-specific init/validate/plan in a follow-up workflow configured per Terraform root module."
+          echo "This repository currently stores Terraform examples across folders, not a single root module."

--- a/README.md
+++ b/README.md
@@ -1,72 +1,57 @@
-# DevSecOps-Multicloud-Blueprint 🚀
+# DevSecOps Multicloud Blueprint
 
-Repositorio técnico y visual profesional para desplegar una arquitectura DevSecOps multicloud enfocada en entornos Fintech.  
-Incluye controles de seguridad, cumplimiento, CI/CD seguro, pruebas automatizadas, comunidad activa y documentación avanzada.
+Blueprint tecnico y visual para disenar una arquitectura DevSecOps multicloud con foco en seguridad, cumplimiento, CI/CD seguro, control de cambios y gobierno operativo.
+
+El objetivo del repositorio es mostrar como estructurar una plataforma DevSecOps enterprise: desde controles de repositorio y seguridad de codigo hasta IAM, compliance, pruebas, arquitectura y documentacion ejecutiva.
 
 ![Arquitectura](blueprint-architecture/diagram-devsecops-fintech.png)
 
----
+## Dominios principales
 
-## 📁 Estructura del Repositorio
+| Dominio | Contenido |
+| --- | --- |
+| `fintech-controls/` | Politicas y diseno seguro orientado a escenarios fintech |
+| `code-security-examples/` | Buenas practicas de seguridad en codigo |
+| `cicd-security/` | Integraciones CI con herramientas de analisis y validacion |
+| `repo-protection/` | Politicas de ramas, secretos y control de cambios |
+| `iam-security/` | Ejemplos para control de acceso en Azure y AWS |
+| `blueprint-architecture/` | Diagramas visuales Visio, PPTX y PNG |
+| `security-tests/` | Simulaciones controladas de pruebas ofensivas |
+| `compliance/` | Checklist formal de cumplimiento |
+| `.github/workflows/` | Automatizaciones de validacion cuando aplique |
 
-| Carpeta | Contenido |
-|--------|-----------|
-| `fintech-controls/` | Políticas y diseño seguro orientado a fintech |
-| `code-security-examples/` | Buenas prácticas de seguridad en código |
-| `cicd-security/` | Integraciones CI con SonarQube y Semgrep |
-| `repo-protection/` | Políticas de ramas, secretos y control de cambios |
-| `iam-security/` | Ejemplos para control de acceso en Azure, AWS |
-| `blueprint-architecture/` | Diagramas visuales Visio/PPTX/PNG |
-| `security-tests/` | Simulaciones de ataques (XSS, pruebas ofensivas) |
-| `compliance/` | Checklist formal de cumplimiento fintech |
-| `.github/workflows/` | Escaneos automáticos de seguridad y CI/CD |
+## Capacidades demostradas
 
----
+- Arquitectura multicloud con Azure, AWS y GCP.
+- DevSecOps y CI/CD seguro.
+- Separacion de entornos Dev, QA y Produccion.
+- Analisis de codigo, contenedores y dependencias.
+- Seguridad por capas: HTTPS, mTLS, Vault/KMS, SIEM e IAM.
+- Gobierno de repositorios: ramas, pull requests, secretos y auditoria.
+- Compliance y trazabilidad para escenarios regulados.
 
-## 🧩 Características Principales
+## Buenas practicas de seguridad
 
-- ✅ Arquitectura multinube (Azure, AWS, GCP)
-- ✅ DevSecOps CI/CD integrado
-- ✅ Entornos separados: Dev, QA, Producción
-- ✅ Análisis de código (Semgrep), contenedores (Trivy)
-- ✅ Seguridad por capas: HTTPS, mTLS, Vault/KMS, SIEM
-- ✅ Cumplimiento: PCI DSS, ISO 27001, SOC 2
+- No publicar secretos ni credenciales reales.
+- Usar placeholders para ejemplos sensibles.
+- Mantener politicas de ramas y revision de cambios.
+- Documentar controles preventivos, detectivos y correctivos.
+- Separar ejemplos educativos de configuraciones productivas.
 
----
+## Gobierno del repositorio
 
-## 📊 Actividad e Insights
+- [Security Policy](SECURITY.md)
+- [Contributing](CONTRIBUTING.md)
+- [License](LICENSE)
 
-- GitHub Actions: Validación automática de código seguro
-- Dependency Graph: Dependencias controladas vía `requirements.txt` y `Dockerfile`
-- Community Standards: 100% completado ✅
-- Código abierto con licencia MIT
-- Contributors visibles y trazables
+## Badges
 
----
-
-## 🤝 Cómo Contribuir
-
-Este repositorio acepta contribuciones bajo las siguientes condiciones:
-
-1. Clonar y hacer fork del proyecto
-2. Crear tu rama con mejoras
-3. Validar con los análisis de seguridad antes de hacer PR
-4. Todo el código debe estar firmado y pasar los checks automáticos
-
-Ver más en [`CONTRIBUTING.md`](CONTRIBUTING.md)
-
----
-
-## 🛡️ Seguridad y Responsabilidad
-
-- Vulnerabilidades deben ser reportadas en [`SECURITY.md`](SECURITY.md)
-- Código bajo licencia MIT – Carlos Crudo 2025 – Cloud Solutions IoT®
-
----
-
-## 🏷️ Badges
-
-![CI Status](https://github.com/ccrudolabs/DevSecOps-Multicloud-Blueprint/actions/workflows/scan.yml/badge.svg)
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
-![Contributors](https://img.shields.io/github/contributors/ccrudolabs/DevSecOps-Multicloud-Blueprint)
 ![Last Commit](https://img.shields.io/github/last-commit/ccrudolabs/DevSecOps-Multicloud-Blueprint)
+![Repository](https://img.shields.io/badge/blueprint-DevSecOps%20Multicloud-0c233c)
+
+## Autor
+
+Carlos Crudo  
+Blog: https://carloscrudo.com/  
+LinkedIn: https://www.linkedin.com/in/carloscrudo/


### PR DESCRIPTION
## Resumen
- Lleva a `develop` el README profesional y el workflow Terraform CI/CD corregido desde `main`.

## Motivo
`develop` tiene trabajo propio y no debe ser sobrescrita. Este back-merge mantiene trazabilidad y permite revisar conflictos o diferencias antes de integrar.